### PR TITLE
Fixes Guild retrieval so plugin works again (PermissionViewer) 

### DIFF
--- a/Plugins/PermissionsViewer/PermissionsViewer.plugin.js
+++ b/Plugins/PermissionsViewer/PermissionsViewer.plugin.js
@@ -224,7 +224,8 @@ module.exports = !global.ZeresPluginLibrary ? Dummy : (([Plugin, Api]) => {
     const {ContextMenu, DOM, Utils} = window.BdApi;
     const {DiscordModules, WebpackModules, Toasts, DiscordClasses, Utilities, DOMTools, ColorConverter, ReactTools} = Api;
 
-    const GuildStore = DiscordModules.GuildStore;
+    const { Webpack } = BdApi;
+    const GuildStore = Webpack.getStore("GuildStore");
     const SelectedGuildStore = DiscordModules.SelectedGuildStore;
     const MemberStore = DiscordModules.GuildMemberStore;
     const UserStore = DiscordModules.UserStore;
@@ -340,13 +341,6 @@ module.exports = !global.ZeresPluginLibrary ? Dummy : (([Plugin, Api]) => {
     animation-fill-mode: forwards;
     animation-delay: 50ms;
     opacity: 0.85;
-}
-
-#permissions-modal-wrapper.closing .modal-wrapper {
-    animation: permissions-modal-wrapper-closing 250ms cubic-bezier(0.19, 1, 0.22, 1);
-    animation-fill-mode: forwards;
-    opacity: 1;
-    transform: scale(1);
 }
 
 #permissions-modal-wrapper .modal-wrapper {
@@ -745,10 +739,12 @@ module.exports = !global.ZeresPluginLibrary ? Dummy : (([Plugin, Api]) => {
         patchGuildContextMenu() {
             this.contextMenuPatches.push(ContextMenu.patch("guild-context", (retVal, props) => {
                 if (!props?.guild) return retVal; // Ignore non-guild items
+                const guild = GuildStore.getGuild(props.guild.id);
+                if (!guild) return retVal;
                 const newItem = ContextMenu.buildItem({
                     label: this.strings.contextMenuLabel,
                     action: () => {
-                        this.showModal(this.createModalGuild(props.guild.name, props.guild));
+                        this.showModal(this.createModalGuild(guild.name, guild));
                     }
                 });
                 retVal.props.children.splice(1, 0, newItem);


### PR DESCRIPTION
Changed;

    const { Webpack } = BdApi;
    const GuildStore = Webpack.getStore("GuildStore");


To fix Guild Retrieval, subsequently fixing the plugin.